### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/busybox.spec
+++ b/rpm/busybox.spec
@@ -18,7 +18,7 @@ URL: https://github.com/sailfishos/busybox
 BuildRequires: glibc-static
 BuildRequires: libselinux-static libsepol-static
 BuildRequires: pcre-static
-BuildRequires: systemd
+BuildRequires: pkgconfig(systemd)
 BuildRequires: sed
 
 Obsoletes: time <= 1.7


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>