### PR TITLE
[busybox] Obsolete old version of busybox-symlinks-cpio. JB#56272

### DIFF
--- a/rpm/busybox.spec
+++ b/rpm/busybox.spec
@@ -28,6 +28,8 @@ Provides: time > 1.7
 Obsoletes: iputils <= 20101006
 Provides: iputils > 20101006
 
+Obsoletes: busybox-symlinks-cpio <= 1.33.1+git2
+
 %define debug_package %{nil}
 
 %description


### PR DESCRIPTION
While counterintuitive, this makes zypper not to remove
busybox-symlinks-cpio while upgrading